### PR TITLE
Add target to example exorcise configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,13 @@ grunt.loadNpmTasks('grunt-exorcise');
 ```js
 grunt.initConfig({
   exorcise: {
-    options: {},
-    files: {
-      'public/js/bundle.map': ['public/js/bundle.js'],
-    },
-  },
+    bundle: {
+      options: {},
+      files: {
+        'public/js/bundle.map': ['public/js/bundle.js'],
+      }
+    }
+  }
 });
 ```
 


### PR DESCRIPTION
Otherwise grunt outputs "Running "exorcise:files" (exorcise) task" and does not extract the source map.
