### PR TITLE
Update exorcist

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "async": "~0.2.10",
     "resumer": "0.0.0",
     "concat-stream": "~1.4.1",
-    "exorcist": "~0.1.5"
+    "exorcist": "^0.4.0"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.6.0",


### PR DESCRIPTION
Hey guys.

I'm having a issue which `grunt-exorcise` not longer extract the inline sourcemap.

Apparently, just by update the `exorcist` version fix #10.

Right? No?