### PR TITLE
Bump exorcist dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "async": "~0.2.10",
     "resumer": "0.0.0",
     "concat-stream": "~1.4.1",
-    "exorcist": "~0.1.5"
+    "exorcist": "~0.4.0"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.6.0",


### PR DESCRIPTION
Fixes issues with old version of dependencies.

See:
- https://github.com/thlorenz/exorcist/commit/64e451116c1873c6deb42d8f25001452d5d08ab7
- https://github.com/substack/node-browserify/issues/1264