### PR TITLE
Map miltiple bundles to destation folder

### DIFF
--- a/tasks/exorcise.js
+++ b/tasks/exorcise.js
@@ -49,7 +49,8 @@ module.exports = function(grunt) {
       var data = fs.readFileSync(src, 'utf8')
       var stream = resumer().queue(data).end()
       var write = concat(function(data) {
-        var out = options.bundleDest || src
+        // map miltiple bundles to destation folder
+        var out = options.bundleDest? path.resolve( options.bundleDest,path.basename(src) ) : src
         grunt.file.write(out, data)
         cb()
       })


### PR DESCRIPTION
Hi Mike,

I'm working on a project that need bundle multiple files, so I have ammended the source to fit multiple bundles, all bundles will be placed in bundleDest folder.

My task:
``` javascript
dev: {
        options:{
            bundleDest: 'dist/js'
        },
        files: [
            {
              expand: true,     // Enable dynamic expansion.
              cwd: 'dist/tmp',      // Src matches are relative to this path.
              src: ['**/*.js'], // Actual pattern(s) to match.
              dest: 'dist/js/',   // Destination path prefix.
              flatten: true,
              ext: '.map',   // Dest filepaths will have this extension.
              extDot: 'first'   // Extensions in filenames begin after the first dot
            }
        ]
    }
```
